### PR TITLE
Change #!/usr/bin/rexx to #!/usr/bin/env rexx

### DIFF
--- a/md5.orx
+++ b/md5.orx
@@ -1,4 +1,4 @@
-#!/usr/bin/rexx
+#!/usr/bin/env rexx
 
 /* Expected results:
    0xd41d8cd98f00b204e9800998ecf8427e <== ""  


### PR DESCRIPTION
Using the environment to locate the rexx executable